### PR TITLE
Fix for samsung one ui app drawer search box microphone

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,12 +48,13 @@
             android:name=".WhisperRecognizeActivity"
             android:exported="true"
             android:clearTaskOnLaunch="true"
-            android:launchMode="singleInstance"
+            android:launchMode="standard"
             android:visibleToInstantApps="true"
             android:theme="@style/Theme.WhisperFloating"
             android:configChanges="orientation|screenLayout|screenSize|keyboardHidden|keyboard|uiMode|density">
             <intent-filter>
                 <action android:name="android.speech.action.RECOGNIZE_SPEECH" />
+                <action android:name="android.speech.action.WEB_SEARCH" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/whisperonnx/WhisperRecognizeActivity.java
+++ b/app/src/main/java/com/whisperonnx/WhisperRecognizeActivity.java
@@ -3,6 +3,8 @@ package com.whisperonnx;
 import static com.whisperonnx.voice_translation.neural_networks.voice.Recognizer.ACTION_TRANSCRIBE;
 
 import android.annotation.SuppressLint;
+import android.app.PendingIntent;
+import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -52,6 +54,15 @@ public class WhisperRecognizeActivity extends AppCompatActivity {
         sp = PreferenceManager.getDefaultSharedPreferences(this);
 
         String targetLang = getIntent().getStringExtra(RecognizerIntent.EXTRA_LANGUAGE);
+        Log.d("WhisperRecognizeActivity", "Incoming Intent Action: " + getIntent().getAction());
+        Log.d("WhisperRecognizeActivity", "Incoming Intent Flags: " + getIntent().getFlags());
+        Log.d("WhisperRecognizeActivity", "getCallingActivity: " + getCallingActivity());
+        Log.d("WhisperRecognizeActivity", "getCallingPackage: " + getCallingPackage());
+        if (getIntent().getExtras() != null) {
+            for (String key : getIntent().getExtras().keySet()) {
+                Log.d("WhisperRecognizeActivity", "Extra: " + key + " = " + getIntent().getExtras().get(key));
+            }
+        }
         String langCode = sp.getString("language", "auto");
         Log.d("WhisperRecognition","default langCode " + langCode);
 
@@ -210,6 +221,62 @@ public class WhisperRecognizeActivity extends AppCompatActivity {
         sendResultIntent.putStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS, results);
         sendResultIntent.putExtra(RecognizerIntent.EXTRA_CONFIDENCE_SCORES, new float[]{1.0f});
         setResult(RESULT_OK, sendResultIntent);
+
+        PendingIntent pendingIntent = null;
+        try {
+            pendingIntent = getIntent().getParcelableExtra(RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to get EXTRA_RESULTS_PENDINGINTENT", e);
+        }
+
+        if (pendingIntent != null) {
+            Intent pendingResultIntent = new Intent();
+            pendingResultIntent.putStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS, results);
+            pendingResultIntent.putExtra(RecognizerIntent.EXTRA_CONFIDENCE_SCORES, new float[]{1.0f});
+            pendingResultIntent.putExtra(SearchManager.QUERY, result);
+
+            if (getIntent().hasExtra(RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT_BUNDLE)) {
+                Bundle pendingIntentBundle = null;
+                try {
+                    pendingIntentBundle = getIntent().getParcelableExtra(RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT_BUNDLE);
+                } catch (Exception e) {
+                    Log.e(TAG, "Failed to get EXTRA_RESULTS_PENDINGINTENT_BUNDLE", e);
+                }
+                if (pendingIntentBundle == null) {
+                    pendingIntentBundle = new Bundle();
+                }
+                pendingIntentBundle.putStringArrayList(RecognizerIntent.EXTRA_RESULTS, results);
+                pendingIntentBundle.putFloatArray(RecognizerIntent.EXTRA_CONFIDENCE_SCORES, new float[]{1.0f});
+                pendingIntentBundle.putString(SearchManager.QUERY, result);
+
+                pendingResultIntent.putExtra(RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT_BUNDLE, pendingIntentBundle);
+            }
+
+            try {
+                pendingIntent.send(this, RESULT_OK, pendingResultIntent);
+            } catch (PendingIntent.CanceledException e) {
+                Log.e(TAG, "PendingIntent cancelled", e);
+            }
+        } else if (getCallingActivity() == null) {
+            String action = getIntent().getAction();
+            if (RecognizerIntent.ACTION_WEB_SEARCH.equals(action)) {
+                Intent webSearchIntent = new Intent(Intent.ACTION_WEB_SEARCH);
+                webSearchIntent.putExtra(SearchManager.QUERY, result);
+                webSearchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                try {
+                    startActivity(webSearchIntent);
+                } catch (Exception e) {
+                    Log.e(TAG, "Failed to start web search intent", e);
+                }
+            } else {
+                android.content.ClipboardManager clipboard = (android.content.ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+                if (clipboard != null) {
+                    android.content.ClipData clip = android.content.ClipData.newPlainText("Whisper result", result);
+                    clipboard.setPrimaryClip(clip);
+                    Toast.makeText(this, R.string.copy_to_clipboard, Toast.LENGTH_SHORT).show();
+                }
+            }
+        }
         finish();
     }
 


### PR DESCRIPTION
## Bug Fixes

- Fixed an issue where using the microphone button in launcher search boxes (such as Samsung One UI Home) would fail to return the recognized voice text. The speech recognition overlay will now correctly deliver results via the launcher's expected `PendingIntent` (using both the standard `RecognizerIntent` results bundle and the `SearchManager.QUERY` string) and populate the search bar.

## New Features

- Added support for launching voice recognition via standard System Web Search shortcuts. If launched directly outside of a search field and without a results pending intent, Whisper+ will now perform a web search or copy the transcribed text to the clipboard so your speech is never lost.

## Commit Details
fix(voice): return results via PendingIntent with SearchManager.QUERY
Change launchMode of WhisperRecognizeActivity from singleInstance to standard. This allows activities starting it via startActivityForResult to receive the results.

Additionally, add support for delivering results via PendingIntent using the EXTRA_RESULTS_PENDINGINTENT extra. This is required by launchers (like Samsung One UI Home) that launch the activity with FLAG_ACTIVITY_NEW_TASK but expect results via a PendingIntent.

Deliver the results under both RecognizerIntent.EXTRA_RESULTS (as a string list) and SearchManager.QUERY (as a flat query string) within the intent and results bundle.

Implement fallbacks (web search or clipboard copy) only when both getCallingActivity and the PendingIntent are null.